### PR TITLE
Handle HttpError separately in auth routes

### DIFF
--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -1,4 +1,4 @@
-import { json, error } from '@sveltejs/kit';
+import { json, error, HttpError } from '@sveltejs/kit';
 import { db } from '$lib/server/database.js';
 import { verifyPassword, createUserSession } from '$lib/server/auth.js';
 
@@ -56,6 +56,9 @@ export async function POST({ request, cookies }) {
       },
     });
   } catch (err) {
+    if (err instanceof HttpError) {
+      throw err;
+    }
     console.error('Login error:', err);
     throw error(500, 'Login failed');
   }

--- a/src/routes/api/auth/register/+server.ts
+++ b/src/routes/api/auth/register/+server.ts
@@ -1,4 +1,4 @@
-import { json, error } from '@sveltejs/kit';
+import { json, error, HttpError } from '@sveltejs/kit';
 import { db } from '$lib/server/database.js';
 import {
   hashPassword,
@@ -63,6 +63,9 @@ export async function POST({ request }) {
       },
     });
   } catch (err) {
+    if (err instanceof HttpError) {
+      throw err;
+    }
     console.error('Registration error:', err);
     throw error(500, 'Registration failed');
   }


### PR DESCRIPTION
## Summary
- ensure login and register route handlers rethrow existing HttpErrors
- keep logging and return 500 responses for unexpected exceptions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2a97b7114832987e7c2b3c81bbaf5